### PR TITLE
Only run fast tests in workflows.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+on: [push, pull_request]
+name: Build
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-C target-cpu=native -D warnings"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --verbose

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,7 +1,27 @@
 on: [push, pull_request]
-name: Build and run tests
+name: Tests
 jobs:
-  build_and_test:
+  test:
+    strategy:
+      matrix:
+        test_case:
+          - "gf2n::test::fast_"
+          - "gf2n::test::clmul_"
+          - "gf2n::test::gf008::"
+          - "gf2n::test::gf016::"
+          - "gf2n::test::gf032::"
+          - "gf2n::test::gf064::"
+          - "gf2n::test::gf128::"
+          - "gf2n::test::gf256::"
+          - "shamir::test::fast_"
+          - "shamir::test::gf008::"
+          - "shamir::test::gf016::"
+          - "shamir::test::gf032::"
+          - "shamir::test::gf064::"
+          - "shamir::test::gf128::"
+          - "shamir::test::gf256::"
+          - "can_split"
+          - "can_reconstruct"
     runs-on: ubuntu-latest
     env:
       RUSTFLAGS: "-C target-cpu=native -D warnings"
@@ -13,14 +33,8 @@ jobs:
           toolchain: nightly
           override: true
 
-      - name: Build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --verbose
-
-      - name: Tests
+      - name: Tests (${{ matrix.test_case }})
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all --verbose
+          args: --release --all ${{ matrix.test_case }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Horcrux - Rust implementation of Shamir's Secret Sharing
 
-![Build Status](https://github.com/gendx/horcrux/workflows/Build%20and%20run%20tests/badge.svg)
+![Build Status](https://github.com/gendx/horcrux/workflows/Build/badge.svg)
+![Test Status](https://github.com/gendx/horcrux/workflows/Tests/badge.svg)
 
 This program is an example implementation of [Shamir's Secret Sharing](https://en.wikipedia.org/wiki/Shamir%27s_Secret_Sharing) in Rust.
 


### PR DESCRIPTION
This pull request updates workflows as follows:
- split building from testing into separate workflows,
- run tests in release mode,
- only run the tests that finish in reasonable time.