### PR TITLE
Add Bip39 Support for field encoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,11 @@ clap = "2.33.3"
 hex = "0.4.3"
 rand = "0.8.4"
 regex = "1"
+tiny-bip39 = { version = "^0.8", optional = true }
 
 [dev-dependencies]
 plotters = "0.3.1"
 plotters-backend = "0.3.2"
+
+[features]
+bip39 = [ "tiny-bip39" ]

--- a/horcrux/src/gf2n.rs
+++ b/horcrux/src/gf2n.rs
@@ -314,6 +314,11 @@ impl<W: Word, const NWORDS: usize, const A: usize, const B: usize, const C: usiz
         Self { words }
     }
 
+    /// Access the underlying bytes
+    pub const fn words(&self) -> [W; NWORDS] {
+        self.words
+    }
+
     #[cfg(test)]
     fn get_nonzero_test_values() -> Vec<Self> {
         let all_ones = [!W::ZERO; NWORDS];

--- a/horcrux/src/shamir.rs
+++ b/horcrux/src/shamir.rs
@@ -19,6 +19,9 @@ pub trait Shamir<F: Field> {
     /// Type for shares split from the secret.
     type Share: Copy + Debug + PartialEq + GetX<Self::X>;
 
+    /// Create a share from its base components
+    fn share(x: Self::X, y: F) -> Self::Share;
+
     /// Splits a secret into n shares, with k shares being sufficient to reconstruct it.
     fn split(secret: &F, k: usize, n: usize) -> Vec<Self::Share>;
 
@@ -110,6 +113,10 @@ impl<F: Field + Debug + Display> Shamir<F> for CompactShamir {
     type X = u8;
     type Share = CompactShare<F>;
 
+    fn share(x: Self::X, y: F) -> Self::Share {
+        Self::Share { x, y }
+    }
+
     fn split(secret: &F, k: usize, n: usize) -> Vec<Self::Share> {
         check_split_parameters(k, n);
 
@@ -200,6 +207,10 @@ impl<F: Field + Debug + Display> Shamir<F> for CompactShamir {
 impl<F: Field + Debug + Display> Shamir<F> for RandomShamir {
     type X = F;
     type Share = RandomShare<F>;
+
+    fn share(x: Self::X, y: F) -> Self::Share {
+        Self::Share { x, y }
+    }
 
     fn split(secret: &F, k: usize, n: usize) -> Vec<Self::Share> {
         check_split_parameters(k, n);

--- a/src/mnemonic.rs
+++ b/src/mnemonic.rs
@@ -1,0 +1,139 @@
+use std::fmt;
+use std::ops::*;
+use std::marker::PhantomData;
+use rand::{CryptoRng, Rng};
+
+use horcrux::field::Field;
+use horcrux::gf2n::{GF128, GF256};
+use horcrux::shamir::{Shamir};
+
+#[cfg(feature = "bip39")]
+use bip39::{Mnemonic, Language};
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Bip39<F> {
+    base: F
+}
+
+impl<F> Bip39<F> {
+    pub const fn new(base: F) -> Self {
+        Self { base }
+    }
+}
+
+#[cfg(feature = "bip39")]
+fn mnemonic<'a, I>(bs: I) -> Mnemonic where I: Iterator<Item = &'a u64> {
+    let bytes: Vec<u8> = bs.map(|w| u64::to_be_bytes(*w)).flatten().collect();
+    Mnemonic::from_entropy(&bytes, Language::English).unwrap()
+}
+
+#[cfg(not(feature = "bip39"))]
+fn mnemonic<I>(_: I) -> ! {
+    panic!("bip39 mnemonics requires the bip39 feature flag")
+}
+
+impl fmt::Display for Bip39<GF128> {
+    #[allow(unreachable_code)]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", mnemonic(self.base.words().iter()))
+    }
+}
+
+impl fmt::Display for Bip39<GF256> {
+    #[allow(unreachable_code)]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", mnemonic(self.base.words().iter()))
+    }
+}
+
+impl<F: Field> Field for Bip39<F> {
+    const ZERO: Self = Self::new(F::ZERO);
+    const ONE: Self = Self::new(F::ONE);
+
+    fn uniform<R: Rng + CryptoRng + ?Sized>(rng: &mut R) -> Self {
+        Self::new(F::uniform(rng))
+    }
+
+    fn invert(self) -> Self {
+        Self::new(self.base.invert())
+    }
+
+    fn from_diff(lhs: u8, rhs: u8) -> Self {
+        Self::new(F::from_diff(lhs, rhs))
+    }
+
+    fn from_bytes(bytes: &[u8]) -> Option<Self> {
+        F::from_bytes(bytes).map(Self::new)
+    }
+}
+
+impl<F: Field> From<u8> for Bip39<F> {
+    fn from(word: u8) -> Self {
+        Self::new(F::from(word))
+    }
+}
+
+impl<F: Field> AddAssign<&Self> for Bip39<F> {
+    fn add_assign(&mut self, other: &Self) {
+        self.base += &other.base
+    }
+}
+
+impl<F: Field> Sub for Bip39<F> {
+    type Output = Self;
+    fn sub(self, other: Self) -> Self {
+        Self::new(self.base - other.base)
+    }
+}
+
+impl<F: Field> Mul<&Self> for Bip39<F> {
+    type Output = Self;
+    fn mul(self, other: &Self) -> Self {
+        Self::new(self.base * &other.base)
+    }
+}
+
+pub struct Bip39Shamir<S> {
+    _phantom_s: PhantomData<S>
+}
+
+impl<F: Field, S: Shamir<F>> Shamir<F> for Bip39Shamir<S> {
+    type X = S::X;
+    type Share = S::Share;
+
+    fn share(x: Self::X, y: F) -> Self::Share {
+        S::share(x, y)
+    }
+
+    fn split(secret: &F, k: usize, n: usize) -> Vec<Self::Share> {
+        S::split(secret, k, n)
+    }
+
+    fn reconstruct(shares: &[Self::Share], k: usize) -> Option<F> {
+        S::reconstruct(shares, k)
+    }
+
+    fn reconstruct_at(shares: &[Self::Share], k: usize, x: Self::X) -> Option<Self::Share> {
+        S::reconstruct_at(shares, k, x)
+    }
+
+    fn parse_x(s: &str) -> Option<Self::X> {
+        S::parse_x(s)
+    }
+
+    #[cfg(feature = "bip39")]
+    fn parse_share(s: &str) -> Option<Self::Share> {
+        use regex::Regex;
+        let regex = Regex::new(r"^([0-9]+)\|(.+)$").unwrap();
+        let captures = regex.captures(s)?;
+        let x = Self::parse_x(&captures[1])?;
+        let mnemonic = Mnemonic::from_phrase(&captures[2], Language::English).ok()?;
+        let y = F::from_bytes(mnemonic.entropy())?;
+        Some(S::share(x, y))
+    }
+
+    #[cfg(not(feature = "bip39"))]
+    fn parse_share(_: &str) -> Option<Self::Share> {
+        panic!("bip39 mnemonics requires the bip39 feature flag")
+    }
+}


### PR DESCRIPTION
Hex secrets are difficult to write down without error. This PR allows for human readable Bip39 input and output. 