### PR TITLE
Use std::hint::black_box for benchmark inputs.

### DIFF
--- a/.github/workflows/benches.yml
+++ b/.github/workflows/benches.yml
@@ -17,4 +17,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --benches --verbose
+          args: --benches --all --verbose

--- a/horcrux/src/gf2n.rs
+++ b/horcrux/src/gf2n.rs
@@ -946,6 +946,7 @@ mod test {
         }
 
         use test::Bencher;
+        use std::hint::black_box;
 
         const TEST_VALUE: F = F::new([!W::ZERO; F::NWORDS]);
 
@@ -953,39 +954,39 @@ mod test {
         fn bench_mul(b: &mut Bencher) {
             let x = TEST_VALUE;
             let y = TEST_VALUE;
-            b.iter(|| x * &y);
+            b.iter(|| black_box(x) * &black_box(y));
         }
 
         #[bench]
         fn bench_mul_as_add(b: &mut Bencher) {
             let x = TEST_VALUE;
             let y = TEST_VALUE;
-            b.iter(|| x.mul_as_add(&y));
+            b.iter(|| black_box(x).mul_as_add(&black_box(y)));
         }
 
         #[bench]
         fn bench_mul_fused_carry(b: &mut Bencher) {
             let x = TEST_VALUE;
             let y = TEST_VALUE;
-            b.iter(|| x.mul_fused_carry(&y));
+            b.iter(|| black_box(x).mul_fused_carry(&black_box(y)));
         }
 
         #[bench]
         fn bench_invert(b: &mut Bencher) {
             let x = TEST_VALUE;
-            b.iter(|| x.invert());
+            b.iter(|| black_box(x).invert());
         }
 
         #[bench]
         fn bench_shl1(b: &mut Bencher) {
             let x = TEST_VALUE;
-            b.iter(|| x.shl1_ret());
+            b.iter(|| black_box(x).shl1_ret());
         }
 
         #[bench]
         fn bench_shlt(b: &mut Bencher) {
             let x = TEST_VALUE;
-            b.iter(|| x.shlt_ret());
+            b.iter(|| black_box(x).shlt_ret());
         }
     }
 
@@ -1030,6 +1031,7 @@ mod test {
         }
 
         use test::Bencher;
+        use std::hint::black_box;
 
         const TEST_VALUE: F = F::new([!W::ZERO; F::NWORDS]);
 
@@ -1037,7 +1039,7 @@ mod test {
         fn bench_mul_clmul(b: &mut Bencher) {
             let x = TEST_VALUE;
             let y = TEST_VALUE;
-            b.iter(|| super::super::mul_clmul_u64(&x, &y));
+            b.iter(|| super::super::mul_clmul_u64(&black_box(x), &black_box(y)));
         }
     }
 }

--- a/horcrux/src/lib.rs
+++ b/horcrux/src/lib.rs
@@ -1,4 +1,4 @@
-#![feature(test, const_fn_trait_bound)]
+#![feature(bench_black_box, test, const_fn_trait_bound)]
 #![deny(missing_docs)]
 
 //! Rust implementation of Shamir's Secret Sharing.

--- a/horcrux/src/shamir.rs
+++ b/horcrux/src/shamir.rs
@@ -654,11 +654,12 @@ mod test {
     use rand::rngs::SmallRng;
     use rand::seq::SliceRandom;
     use rand::SeedableRng;
+    use std::hint::black_box;
     use test::Bencher;
 
     fn bench_split<F: Field + Debug, S: Shamir<F> + ?Sized>(b: &mut Bencher, k: usize, n: usize) {
         let secret = F::uniform(&mut thread_rng());
-        b.iter(|| S::split(&secret, k, n));
+        b.iter(|| S::split(black_box(&secret), k, n));
     }
 
     fn bench_reconstruct<F: Field + Debug, S: Shamir<F> + ?Sized>(
@@ -668,7 +669,7 @@ mod test {
     ) {
         let secret = F::uniform(&mut thread_rng());
         let shares = S::split(&secret, k, n);
-        b.iter(|| S::reconstruct(&shares, k));
+        b.iter(|| S::reconstruct(black_box(&shares), k));
     }
 
     fn bench_reconstruct_arbitrary<F: Field + std::fmt::Debug, S: Shamir<F> + ?Sized>(
@@ -683,7 +684,7 @@ mod test {
         b.iter(|| {
             // Pick arbitrary values on each run.
             let (chosen, _) = shares.partial_shuffle(&mut rng, k);
-            S::reconstruct(&chosen, k)
+            S::reconstruct(black_box(&chosen), k)
         });
     }
 
@@ -695,7 +696,7 @@ mod test {
         let secret = F::uniform(&mut thread_rng());
         let shares = S::split(&secret, k, n);
         let x = S::X::from(42);
-        b.iter(|| S::reconstruct_at(&shares, k, x));
+        b.iter(|| S::reconstruct_at(black_box(&shares), k, black_box(x)));
     }
 
     fn bench_reconstruct_at_arbitrary<F: Field + std::fmt::Debug, S: Shamir<F> + ?Sized>(
@@ -711,7 +712,7 @@ mod test {
         b.iter(|| {
             // Pick arbitrary values on each run.
             let (chosen, _) = shares.partial_shuffle(&mut rng, k);
-            S::reconstruct_at(&chosen, k, x)
+            S::reconstruct_at(black_box(&chosen), k, black_box(x))
         });
     }
 }


### PR DESCRIPTION
This updates the benchmarks to use `std::hint::black_box` on the inputs, as mentioned in the [documentation](https://doc.rust-lang.org/nightly/unstable-book/library-features/test.html#gotcha-optimizations).